### PR TITLE
Add check for GMSA with account name too long

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -739,6 +739,10 @@ if (($scope -eq "Tier-1") -or ($scope -eq "All-Tiers")){
 }
 #create the GMSA if the Tier Level isolation works in Mulit-Domain-Domain Forest mode
 $strReadHost = Read-Host "Group Managed Service AccountName ($DefaultGMSAName)"
+while ($strReadHost.Length -gt 15) {
+    Write-Host "The service account has a samAccountName attribute of '$strReadHost' which is too long; the samAccountName attribute must not be longer than 15 characters."
+    $strReadHost = Read-Host "Group Managed Service AccountName ($DefaultGMSAName)"
+}
 if ($strReadHost -eq '') {$strReadHost = $DefaultGMSAName}
 $GMSAName = $strReadHost
 if ($null -eq (Get-ADServiceAccount -Filter "name -eq '$GMSAName'")){


### PR DESCRIPTION
This is untested, but a problem I ran into that made the script install harder than it needs to be. There is probably a lot more checks that can be done, but it's a start :)