### PR TITLE
Tierlevelusermanagement bugfixes

### DIFF
--- a/TierLevelUserManagement.ps1
+++ b/TierLevelUserManagement.ps1
@@ -107,14 +107,19 @@ function Write-Log {
         [int]$EventID
     )
 
+    
     #Format the log message and write it to the log file
     $LogLine = "$(Get-Date -Format o), [$Severity],[$EventID], $Message"
-    Add-Content -Path $LogFile -Value $LogLine 
+    if ($LogFile -ne $null) { #Safety check to make sure logfile isnt null
+        Add-Content -Path $LogFile -Value $LogLine
+    }
     #If the severity is not debug write the even to the event log and format the output
     switch ($Severity) {
         'Error' { 
             Write-Host $Message -ForegroundColor Red
-            Add-Content -Path $LogFile -Value $Error[0].ScriptStackTrace 
+            if ($LogFile -ne $null) { #Safety check to make sure logfile isnt null
+                Add-Content -Path $LogFile -Value $Error[0].ScriptStackTrace 
+            }
             Write-EventLog -LogName $eventLog -source $source -EventId $EventID -EntryType Error -Message $Message -Category 0
         }
         'Warning' { 

--- a/TierLevelUserManagement.ps1
+++ b/TierLevelUserManagement.ps1
@@ -397,10 +397,12 @@ try{
     #if the configuration is avaiable in the Active Directory configuration partition, the script will read the configuration from the AD
     #otherwise try to use the default configuration file
     if ($ConfigFile -eq '') {
-        if ($null -ne (Get-ADObject -Filter "DistinguishedName -eq '$ADconfigurationPath'")){
-            #Write-Log -Message "Read config from AD configuration partition" -Severity Debug -EventID 1002
-            Write-host "AD config lesen noch implementieren" -ForegroundColor Red -BackgroundColor DarkGray
-            return
+        if ($null -ne $ADconfigurationPath){ #Check that $ADconfigurationPath is not null to avoid exeption with Get-ADObject
+            if ($null -ne (Get-ADObject -Filter "DistinguishedName -eq '$ADconfigurationPath'")){
+                #Write-Log -Message "Read config from AD configuration partition" -Severity Debug -EventID 1002
+                Write-host "AD config lesen noch implementieren" -ForegroundColor Red -BackgroundColor DarkGray
+                return
+            }
         } else {
             #last resort if the configfile paramter is not available and no configuration is stored in the AD. check for the dafault configuration file
             if ($null -eq $config){


### PR DESCRIPTION
Added a safety check in the region read configuration where Get-ADObject was run with invalid filter when $ADConfigurationPath was unset. It now checks that the path is not null before running Get-ADObject. 

Added two safety checks in the Write-Log function, where it attempts to use the Add-Content cmdlet even if the path to the logfile was empty in the configuration. The safety checks make sure the cmdlet isnt run without a proper path, to avoid throwing errors.

These two fixes stops the user management script from failing with a generic "error reading configuration" message in the event log.