### PR TITLE
Uncomment $ADConfiguration assignment, updated version string

### DIFF
--- a/TierLevelUserManagement.ps1
+++ b/TierLevelUserManagement.ps1
@@ -61,6 +61,9 @@ possibility of such damages
         If a alternative logfile path in the configuration file is not set, the script will use the local appdata path of the user running the script.
     Version 0.2.20250619
         Fixed a error writing to event log
+    Version 0.2.20250623
+        Fixed missing ADConfiguration path in TierLevelUserManagement, preventing authentication policy management
+
 
 #>
 param(
@@ -361,7 +364,7 @@ function ConvertTo-DistinguishedNames{
 # Main program starts here
 ##############################################################################################################################
 #script Version 
-$ScriptVersion = "0.2.20250429"
+$ScriptVersion = "0.2.20250623"
 try {   
     $eventLog = "Application"
     $source = "TierLevelIsolation"
@@ -379,7 +382,7 @@ $config = $null
 #the current domain must contains the Tier level user groups
 $CurrentDomainDNS = (Get-ADDomain).DNSRoot
 $DefaultConfigFile = "\\$CurrentDomainDNS\SYSVOL\$CurrentDomainDNS\scripts\TierLevelIsolation.config"
-#$ADconfigurationPath = "CN=Tier Level Isolation,CN=Services,$((Get-ADRootDSE).configurationNamingContext)"
+$ADconfigurationPath = "CN=Tier Level Isolation,CN=Services,$((Get-ADRootDSE).configurationNamingContext)"
 
 # relative SID of privileged groups
 $PrivlegeDomainSid = @(


### PR DESCRIPTION
There is an inconsistency between TierLevelUserManagement.ps1 and TierLevelComputerManagement.ps1, where $ADConfiguration gets a default assignment for ComputerManagement but not for UserManagement. Unfortunately that breaks the try / catch section and results in a never running UserManagement.

The only change (aside from updating the version string) is to re-add the assignment in UserManagement to get it working againg (and have it be consistent with ComputerManagement).

This fixes [#7](https://github.com/Kili69/TierLevelIsolation/issues/7)